### PR TITLE
Split the ci workflow into two

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,6 @@
-name: CI
+name: Pull Request
 
-on:
-  push:
-    branches: [main]
+on: pull_request
 
 env:
   DOTNET_NOLOGO: true
@@ -17,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.3.3
 
       - name: Build version suffix
-        run: echo "VERSION_SUFFIX=beta.${{ github.run_number }}" >> $GITHUB_ENV
+        run: echo "VERSION_SUFFIX=alpha.${{ github.event.number }}" >> $GITHUB_ENV
 
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
@@ -31,10 +29,6 @@ jobs:
 
       - name: Setup .NET Core (global.json)
         uses: actions/setup-dotnet@v1.7.2
-        with:
-          source-url: https://nuget.pkg.github.com/xt0rted/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: npm ci
 
@@ -48,6 +42,3 @@ jobs:
         uses: actions/upload-artifact@v2.2.0
         with:
           path: ./artifacts/*
-
-      - name: Publish to GPR
-        run: dotnet nuget push ./artifacts/*.nupkg --no-symbols true --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # heroicons-tag-helper
 
+[![CI build status](https://github.com/xt0rted/heroicons-tag-helper/workflows/CI/badge.svg)](https://github.com/xt0rted/heroicons-tag-helper/actions?query=workflow%3ACI)
 [![GitHub Package Registry](https://img.shields.io/badge/github-package_registry-yellow?logo=nuget)](https://nuget.pkg.github.com/xt0rted/index.json)
 [![Project license](https://img.shields.io/github/license/xt0rted/heroicons-tag-helper)](LICENSE)
 


### PR DESCRIPTION
This will keep the ci build numbers low since every pr build was increasing them