### PR TITLE
Add a setting to include an html comment with icon info

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ In your `_ViewImports.cshtml` add:
 @addTagHelper *, HeroiconsTagHelper
 ```
 
+In your `Startup.cs` add:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddHeroicons(Configuration);
+}
+```
+
+In your `appsettings.json` add:
+
+```json
+{
+  "Heroicons": {
+    "IncludeComments": true
+  }
+}
+
+```
+
+## Settings
+
+### IncludeComments
+
+Setting this to `true` will add an html comment before the svg tag with the style and name of the icon to help make development/debugging easier.
+
 ## Usage
 
 There are two versions of the tag helper which are used to pick between the `outline` and `solid` icon styles.

--- a/generator/IconExtractor.cs
+++ b/generator/IconExtractor.cs
@@ -1,4 +1,4 @@
-namespace IconSourceGenerator
+﻿namespace IconSourceGenerator
 {
     using System;
     using System.Linq;

--- a/generator/IconSourceGenerator.cs
+++ b/generator/IconSourceGenerator.cs
@@ -1,4 +1,4 @@
-namespace IconSourceGenerator
+﻿namespace IconSourceGenerator
 {
     using System;
     using System.Collections.Generic;

--- a/generator/IconSourceGenerator.cs
+++ b/generator/IconSourceGenerator.cs
@@ -117,6 +117,7 @@ namespace Tailwind.Heroicons
                     source.AppendLine("                case IconSymbol." + icon.ClassName + ":");
                     source.AppendLine("                    return new Icon");
                     source.AppendLine("                    {");
+                    source.Append("                        Name = \"").Append(icon.Name).AppendLine("\",");
                     source.Append("                        Path = \"").Append(path.Replace("\"", "\\\"")).AppendLine("\",");
                     source.Append("                        ViewBox = \"").Append(viewBox).AppendLine("\",");
                     source.AppendLine("                    };");
@@ -135,6 +136,7 @@ namespace Tailwind.Heroicons
 
     public class Icon
     {
+        public string Name { get; set; }
         public string Path { get; set; }
         public string ViewBox { get; set; }
     }

--- a/generator/StringExtensions.cs
+++ b/generator/StringExtensions.cs
@@ -1,4 +1,4 @@
-namespace IconSourceGenerator
+﻿namespace IconSourceGenerator
 {
     internal static class StringExtensions
     {

--- a/sample/Controllers/HomeController.cs
+++ b/sample/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-namespace Sample.Controllers
+﻿namespace Sample.Controllers
 {
     using Microsoft.AspNetCore.Mvc;
 

--- a/sample/Program.cs
+++ b/sample/Program.cs
@@ -1,4 +1,4 @@
-namespace Sample
+﻿namespace Sample
 {
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;

--- a/sample/Properties/launchSettings.json
+++ b/sample/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,

--- a/sample/Startup.cs
+++ b/sample/Startup.cs
@@ -19,6 +19,8 @@
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllersWithViews();
+
+            services.AddHeroicons(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/sample/Startup.cs
+++ b/sample/Startup.cs
@@ -1,4 +1,4 @@
-namespace Sample
+﻿namespace Sample
 {
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;

--- a/sample/Views/Home/Index.cshtml
+++ b/sample/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-<div>
+﻿<div>
     <div class="p-4">
         <div class="flex justify-center items-end">
             <heroicon-outline icon="Sun" class="w-6 text-red-500" />

--- a/sample/Views/Shared/_Layout.cshtml
+++ b/sample/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />

--- a/sample/Views/_ViewImports.cshtml
+++ b/sample/Views/_ViewImports.cshtml
@@ -1,1 +1,1 @@
-@addTagHelper *, HeroiconsTagHelper
+﻿@addTagHelper *, HeroiconsTagHelper

--- a/sample/appsettings.Development.json
+++ b/sample/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Heroicons": {
+    "IncludeComments": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/sample/appsettings.json
+++ b/sample/appsettings.json
@@ -1,10 +1,10 @@
 {
+  "AllowedHosts": "*",
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-  },
-  "AllowedHosts": "*"
+  }
 }

--- a/src/HeroiconOptions.cs
+++ b/src/HeroiconOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace Tailwind.Heroicons
+{
+    public class HeroiconOptions
+    {
+        /// <summary>
+        /// Add an html comment before the svg tag with the style and name of the icon.
+        /// </summary>
+        /// <remarks>This is off by default.</remarks>
+        public bool IncludeComments { get; set; }
+    }
+}

--- a/src/HeroiconsExtensions.cs
+++ b/src/HeroiconsExtensions.cs
@@ -1,0 +1,31 @@
+﻿namespace Microsoft.Extensions.DependencyInjection
+{
+    using System;
+
+    using Microsoft.Extensions.Configuration;
+
+    using Tailwind.Heroicons;
+
+    public static class HeroiconsExtensions
+    {
+        public static IServiceCollection AddHeroicons(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services is null) throw new ArgumentNullException(nameof(services));
+            if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
+            services.Configure<HeroiconOptions>(configuration.GetSection("Heroicons"));
+
+            return services;
+        }
+
+        public static IServiceCollection AddHeroicons(this IServiceCollection services, Action<HeroiconOptions> configureOptions)
+        {
+            if (services is null) throw new ArgumentNullException(nameof(services));
+            if (configureOptions is null) throw new ArgumentNullException(nameof(configureOptions));
+
+            services.Configure(configureOptions);
+
+            return services;
+        }
+    }
+}

--- a/src/IconTagHelper.cs
+++ b/src/IconTagHelper.cs
@@ -1,4 +1,4 @@
-namespace Tailwind.Heroicons
+﻿namespace Tailwind.Heroicons
 {
     using System;
 

--- a/src/IconTagHelper.cs
+++ b/src/IconTagHelper.cs
@@ -3,18 +3,26 @@
     using System;
 
     using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Microsoft.Extensions.Options;
 
     [HtmlTargetElement("heroicon-outline", TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("heroicon-solid", TagStructure = TagStructure.WithoutEndTag)]
     public class IconTagHelper : TagHelper
     {
+        private readonly HeroiconOptions _settings;
+
+        public IconTagHelper(IOptions<HeroiconOptions> settings)
+        {
+            _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+        }
+
         [HtmlAttributeName("icon")]
         public IconSymbol Icon { get; set; }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (context == null) throw new ArgumentNullException(nameof(context));
-            if (output == null) throw new ArgumentNullException(nameof(output));
+            if (context is null) throw new ArgumentNullException(nameof(context));
+            if (output is null) throw new ArgumentNullException(nameof(output));
 
             var isSolid = context.TagName.Equals("heroicon-solid", StringComparison.OrdinalIgnoreCase);
 
@@ -40,6 +48,15 @@
             output.Attributes.Add("viewbox", icon.ViewBox);
 
             output.Content.AppendHtml(icon.Path);
+
+            if (_settings.IncludeComments)
+            {
+                output.PreElement.AppendHtml("<!-- Heroicon name: ");
+                output.PreElement.AppendHtml(isSolid ? "solid" : "outline");
+                output.PreElement.AppendHtml(" ");
+                output.PreElement.Append(icon.Name);
+                output.PreElement.AppendHtml(" -->");
+            }
         }
     }
 }

--- a/test/IconListTests.cs
+++ b/test/IconListTests.cs
@@ -1,4 +1,4 @@
-namespace Tailwind.Heroicons
+﻿namespace Tailwind.Heroicons
 {
     using Shouldly;
 

--- a/test/IconTagHelperTests.cs
+++ b/test/IconTagHelperTests.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
 
     using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Microsoft.Extensions.Options;
 
     using Shouldly;
 
@@ -19,7 +20,8 @@
             var context = MakeTagHelperContext(tagName: "heroicon-outline");
             var output = MakeTagHelperOutput(tagName: "heroicon-outline");
 
-            var helper = new IconTagHelper();
+            var options = Options.Create(new HeroiconOptions());
+            var helper = new IconTagHelper(options);
 
             // When
             helper.Process(context, output);
@@ -41,7 +43,8 @@
             var context = MakeTagHelperContext(tagName);
             var output = MakeTagHelperOutput(tagName);
 
-            var helper = new IconTagHelper
+            var options = Options.Create(new HeroiconOptions());
+            var helper = new IconTagHelper(options)
             {
                 Icon = IconSymbol.Bell
             };
@@ -66,7 +69,8 @@
             var context = MakeTagHelperContext(tagName);
             var output = MakeTagHelperOutput(tagName);
 
-            var helper = new IconTagHelper
+            var options = Options.Create(new HeroiconOptions());
+            var helper = new IconTagHelper(options)
             {
                 Icon = IconSymbol.Bell
             };
@@ -101,7 +105,8 @@
                     { attributeName, attributeValue },
                 });
 
-            var helper = new IconTagHelper
+            var options = Options.Create(new HeroiconOptions());
+            var helper = new IconTagHelper(options)
             {
                 Icon = IconSymbol.Bell
             };
@@ -111,6 +116,52 @@
 
             // Then
             output.Attributes.ShouldContain(new TagHelperAttribute(attributeName, attributeValue));
+        }
+
+        [Fact]
+        public void Should_not_include_html_comment_when_IncludeComments_is_false()
+        {
+            // Given
+            var context = MakeTagHelperContext(tagName: "heroicon-outline");
+            var output = MakeTagHelperOutput(tagName: "heroicon-outline");
+
+            var options = Options.Create(new HeroiconOptions
+            {
+                IncludeComments = false,
+            });
+            var helper = new IconTagHelper(options)
+            {
+                Icon = IconSymbol.Bell,
+            };
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            output.PreElement.GetContent().ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Should_include_html_comment_when_IncludeComments_is_true()
+        {
+            // Given
+            var context = MakeTagHelperContext(tagName: "heroicon-outline");
+            var output = MakeTagHelperOutput(tagName: "heroicon-outline");
+
+            var options = Options.Create(new HeroiconOptions
+            {
+                IncludeComments = true,
+            });
+            var helper = new IconTagHelper(options)
+            {
+                Icon = IconSymbol.Bell,
+            };
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            output.PreElement.GetContent().ShouldBe("<!-- Heroicon name: outline bell -->");
         }
 
         private static TagHelperContext MakeTagHelperContext(string tagName, TagHelperAttributeList attributes = null)

--- a/test/IconTagHelperTests.cs
+++ b/test/IconTagHelperTests.cs
@@ -1,4 +1,4 @@
-namespace Tailwind.Heroicons
+﻿namespace Tailwind.Heroicons
 {
     using System;
     using System.Collections.Generic;


### PR DESCRIPTION
This was inspired by the html snippets on [tailwindui.com](https://tailwindui.com/) which include the icon's name and make it much easier during development/debugging to see what icon you're looking at.

The setting is off by default so it doesn't add extra html to your page.

![image](https://user-images.githubusercontent.com/831974/97384586-5daa1f00-18a6-11eb-9d43-6434aa2c0c76.png)
