### PR TITLE
Add settings for `focusable` and accessibility attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ In your `appsettings.json` add:
 
 ## Settings
 
-### IncludeComments
-
-Setting this to `true` will add an html comment before the svg tag with the style and name of the icon to help make development/debugging easier.
+Name | Default Value | Description
+:-- | :-- | :--
+`IncludeComments` | `false` | Add an html comment before the svg tag with the style and name of the icon to help make development/debugging easier.
+`SetFocusableAttribute` | `false` | Adds the `focusable` attribute set to `false` to prevent the icon from receiving focus in Internet Explorer and Edge Legacy.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ In your `appsettings.json` add:
 Name | Default Value | Description
 :-- | :-- | :--
 `IncludeComments` | `false` | Add an html comment before the svg tag with the style and name of the icon to help make development/debugging easier.
+`SetAccessibilityAttributes` | `false` | Adds various accessibility attributes based on the default state of the tag.
 `SetFocusableAttribute` | `false` | Adds the `focusable` attribute set to `false` to prevent the icon from receiving focus in Internet Explorer and Edge Legacy.
+
+### SetAccessibilityAttributes
+
+If `aria-label` or `aria-labeledby` are set then the icon is being used as an image so [`role="img"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Role_Img#svg_and_roleimg) will be added to the svg tag, otherwise [`aria-hidden="true"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute) will be added.
 
 ## Usage
 

--- a/sample/Views/Home/Index.cshtml
+++ b/sample/Views/Home/Index.cshtml
@@ -1,23 +1,23 @@
 ﻿<div>
     <div class="p-4">
         <div class="flex justify-center items-end">
-            <heroicon-outline icon="Sun" class="w-6 text-red-500" />
-            <heroicon-outline icon="Sun" class="w-8 text-orange-500" />
-            <heroicon-outline icon="Sun" class="w-10 text-yellow-500" />
-            <heroicon-outline icon="Sun" class="w-12 text-green-500" />
-            <heroicon-outline icon="Sun" class="w-16 text-teal-500" />
-            <heroicon-outline icon="Sun" class="w-20 text-blue-500" />
-            <heroicon-outline icon="Sun" class="w-24 text-indigo-500" />
-            <heroicon-outline icon="Sun" class="w-32 text-purple-500" />
-            <heroicon-outline icon="Sun" class="w-40 text-pink-500" />
-            <heroicon-outline icon="Sun" class="w-32 text-purple-500" />
-            <heroicon-outline icon="Sun" class="w-24 text-indigo-500" />
-            <heroicon-outline icon="Sun" class="w-20 text-blue-500" />
-            <heroicon-outline icon="Sun" class="w-16 text-teal-500" />
-            <heroicon-outline icon="Sun" class="w-12 text-green-500" />
-            <heroicon-outline icon="Sun" class="w-10 text-yellow-500" />
-            <heroicon-outline icon="Sun" class="w-8 text-orange-500" />
-            <heroicon-outline icon="Sun" class="w-6 text-red-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-6 text-red-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-8 text-orange-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-10 text-yellow-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-12 text-green-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-16 text-teal-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-20 text-blue-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-24 text-indigo-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-32 text-purple-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-40 text-pink-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-32 text-purple-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-24 text-indigo-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-20 text-blue-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-16 text-teal-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-12 text-green-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-10 text-yellow-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-8 text-orange-500" />
+            <heroicon-outline icon="Sun" aria-label="The sun" class="w-6 text-red-500" />
         </div>
         <div class="mt-2 flex justify-center items-start">
             <heroicon-solid icon="Star" class="w-6 text-red-500" />

--- a/sample/appsettings.Development.json
+++ b/sample/appsettings.Development.json
@@ -1,6 +1,7 @@
 {
   "Heroicons": {
-    "IncludeComments": true
+    "IncludeComments": true,
+    "SetFocusableAttribute": true
   },
   "Logging": {
     "LogLevel": {

--- a/sample/appsettings.Development.json
+++ b/sample/appsettings.Development.json
@@ -1,6 +1,7 @@
 {
   "Heroicons": {
     "IncludeComments": true,
+    "SetAccessibilityAttributes": true,
     "SetFocusableAttribute": true
   },
   "Logging": {

--- a/src/HeroiconOptions.cs
+++ b/src/HeroiconOptions.cs
@@ -3,9 +3,15 @@
     public class HeroiconOptions
     {
         /// <summary>
-        /// Add an html comment before the svg tag with the style and name of the icon.
+        /// Add an html comment before the svg tag with the style and name of the icon to help make development/debugging easier.
         /// </summary>
         /// <remarks>This is off by default.</remarks>
         public bool IncludeComments { get; set; }
+
+        /// <summary>
+        /// Adds the <c>focusable</c> attribute set to <c>false</c> to prevent the icon from receiving focus in Internet Explorer and Edge Legacy.
+        /// </summary>
+        /// <remarks>This is off by default.</remarks>
+        public bool SetFocusableAttribute { get; set; }
     }
 }

--- a/src/HeroiconOptions.cs
+++ b/src/HeroiconOptions.cs
@@ -9,6 +9,12 @@
         public bool IncludeComments { get; set; }
 
         /// <summary>
+        /// Adds various accessibility attributes based on the default state of the tag.
+        /// </summary>
+        /// <remarks>This is off by default.</remarks>
+        public bool SetAccessibilityAttributes { get; set; }
+
+        /// <summary>
         /// Adds the <c>focusable</c> attribute set to <c>false</c> to prevent the icon from receiving focus in Internet Explorer and Edge Legacy.
         /// </summary>
         /// <remarks>This is off by default.</remarks>

--- a/src/IconAccessibilityTagHelper.cs
+++ b/src/IconAccessibilityTagHelper.cs
@@ -1,0 +1,48 @@
+﻿namespace Tailwind.Heroicons
+{
+    using System;
+
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Microsoft.Extensions.Options;
+
+    [HtmlTargetElement("heroicon-outline")]
+    [HtmlTargetElement("heroicon-solid")]
+    public class IconAccessibilityTagHelper : TagHelper
+    {
+        private readonly HeroiconOptions _settings;
+
+        public IconAccessibilityTagHelper(IOptions<HeroiconOptions> settings)
+        {
+            _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+        }
+
+        public override int Order => 1000;
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context is null) throw new ArgumentNullException(nameof(context));
+            if (output is null) throw new ArgumentNullException(nameof(output));
+
+            if (!_settings.SetAccessibilityAttributes)
+            {
+                return;
+            }
+
+            var ariaLabel = output.Attributes["aria-label"]?.ToStringValue();
+            var ariaLabeledBy = output.Attributes["aria-labeledby"]?.ToStringValue();
+
+            var isUsedAsImage =
+                !string.IsNullOrWhiteSpace(ariaLabel) ||
+                !string.IsNullOrWhiteSpace(ariaLabeledBy);
+
+            if (isUsedAsImage)
+            {
+                output.Attributes.SetAttribute("role", "img");
+            }
+            else
+            {
+                output.Attributes.SetAttribute("aria-hidden", "true");
+            }
+        }
+    }
+}

--- a/src/IconFocusableTagHelper.cs
+++ b/src/IconFocusableTagHelper.cs
@@ -1,0 +1,34 @@
+﻿namespace Tailwind.Heroicons
+{
+    using System;
+
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Microsoft.Extensions.Options;
+
+    [HtmlTargetElement("heroicon-outline")]
+    [HtmlTargetElement("heroicon-solid")]
+    public class IconFocusableTagHelper : TagHelper
+    {
+        private readonly HeroiconOptions _settings;
+
+        public IconFocusableTagHelper(IOptions<HeroiconOptions> settings)
+        {
+            _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+        }
+
+        public override int Order => 1000;
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context is null) throw new ArgumentNullException(nameof(context));
+            if (output is null) throw new ArgumentNullException(nameof(output));
+
+            if (!_settings.SetFocusableAttribute)
+            {
+                return;
+            }
+
+            output.Attributes.SetAttribute("focusable", "false");
+        }
+    }
+}

--- a/src/IconTagHelper.cs
+++ b/src/IconTagHelper.cs
@@ -38,8 +38,6 @@
             output.TagMode = TagMode.StartTagAndEndTag;
             output.TagName = "svg";
 
-            output.Attributes.Add("aria-hidden", "true");
-
             if (isSolid)
             {
                 output.Attributes.SetAttribute("fill", "currentColor");

--- a/src/IconTagHelper.cs
+++ b/src/IconTagHelper.cs
@@ -40,15 +40,15 @@
 
             if (isSolid)
             {
-                output.Attributes.Add("fill", "currentColor");
+                output.Attributes.SetAttribute("fill", "currentColor");
             }
             else
             {
-                output.Attributes.Add("fill", "none");
-                output.Attributes.Add("stroke", "currentColor");
+                output.Attributes.SetAttribute("fill", "none");
+                output.Attributes.SetAttribute("stroke", "currentColor");
             }
 
-            output.Attributes.Add("viewbox", icon.ViewBox);
+            output.Attributes.SetAttribute("viewbox", icon.ViewBox);
 
             output.Content.AppendHtml(icon.Path);
 

--- a/src/IconTagHelper.cs
+++ b/src/IconTagHelper.cs
@@ -16,6 +16,8 @@
             _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
         }
 
+        public override int Order => 0;
+
         [HtmlAttributeName("icon")]
         public IconSymbol Icon { get; set; }
 

--- a/src/TagHelperAttributeExtensions.cs
+++ b/src/TagHelperAttributeExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Tailwind.Heroicons
+{
+    using Microsoft.AspNetCore.Html;
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+
+    internal static class TagHelperAttributeExtensions
+    {
+        public static string ToStringValue(this TagHelperAttribute attribute) =>
+            attribute.Value switch
+            {
+                HtmlString htmlString => htmlString.ToString(),
+                string stringValue => stringValue,
+                _ => null,
+            };
+    }
+}

--- a/test/IconAccessibilityTagHelperTests.cs
+++ b/test/IconAccessibilityTagHelperTests.cs
@@ -1,0 +1,76 @@
+﻿namespace Tailwind.Heroicons
+{
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Microsoft.Extensions.Options;
+
+    using Shouldly;
+
+    using Xunit;
+
+    public class IconAccessibilityTagHelperTests : TagHelperTestBase
+    {
+        [Fact]
+        public void Should_not_set_accessibility_attributes_when_disabled()
+        {
+            // Given
+            var context = MakeTagHelperContext("heroicon-outline");
+            var output = MakeTagHelperOutput("heroicon-outline");
+
+            var options = Options.Create(new HeroiconOptions { SetAccessibilityAttributes = false });
+            var helper = new IconAccessibilityTagHelper(options);
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            output.Attributes.ShouldNotContain(a => a.Name == "aria-hidden");
+            output.Attributes.ShouldNotContain(a => a.Name == "role");
+        }
+
+        [Theory]
+        [InlineData("aria-label")]
+        [InlineData("aria-labeledby")]
+        public void Should_set_role_attribute_when_label_attribute_is_set(string attributeName)
+        {
+            // Given
+            var context = MakeTagHelperContext(
+                "heroicon-outline",
+                new TagHelperAttributeList
+                {
+                    { attributeName, "test" },
+                });
+            var output = MakeTagHelperOutput(
+                "heroicon-outline",
+                new TagHelperAttributeList
+                {
+                    { attributeName, "test" },
+                });
+
+            var options = Options.Create(new HeroiconOptions { SetAccessibilityAttributes = true });
+            var helper = new IconAccessibilityTagHelper(options);
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            AssertAttributeValue(output.Attributes, "role", "img");
+        }
+
+        [Fact]
+        public void Should_set_aria_hidden_attribute_to_true_when_not_used_as_an_image()
+        {
+            // Given
+            var context = MakeTagHelperContext("heroicon-outline");
+            var output = MakeTagHelperOutput("heroicon-outline");
+
+            var options = Options.Create(new HeroiconOptions { SetAccessibilityAttributes = true });
+            var helper = new IconAccessibilityTagHelper(options);
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            AssertAttributeValue(output.Attributes, "aria-hidden", "true");
+        }
+    }
+}

--- a/test/IconFocusableTagHelperTests.cs
+++ b/test/IconFocusableTagHelperTests.cs
@@ -1,0 +1,73 @@
+﻿namespace Tailwind.Heroicons
+{
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Microsoft.Extensions.Options;
+
+    using Shouldly;
+
+    using Xunit;
+
+    public class IconFocusableTagHelperTests : TagHelperTestBase
+    {
+        [Fact]
+        public void Should_not_set_focusable_attribute_when_disabled()
+        {
+            // Given
+            var context = MakeTagHelperContext("heroicon-outline");
+            var output = MakeTagHelperOutput("heroicon-outline");
+
+            var options = Options.Create(new HeroiconOptions { SetFocusableAttribute = false });
+            var helper = new IconFocusableTagHelper(options);
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            output.Attributes.ShouldNotContain(a => a.Name == "focusable");
+        }
+
+        [Fact]
+        public void Should_set_focusable_attribute()
+        {
+            // Given
+            var context = MakeTagHelperContext("heroicon-outline");
+            var output = MakeTagHelperOutput("heroicon-outline");
+
+            var options = Options.Create(new HeroiconOptions { SetFocusableAttribute = true });
+            var helper = new IconFocusableTagHelper(options);
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            AssertAttributeValue(output.Attributes, "focusable", "false");
+        }
+
+        [Fact]
+        public void Should_set_focusable_attribute_to_false()
+        {
+            // Given
+            var context = MakeTagHelperContext(
+                "heroicon-outline",
+                new TagHelperAttributeList
+                {
+                    { "focusable", "true" },
+                });
+            var output = MakeTagHelperOutput(
+                "heroicon-outline",
+                new TagHelperAttributeList
+                {
+                    { "focusable", "true" },
+                });
+
+            var options = Options.Create(new HeroiconOptions { SetFocusableAttribute = true });
+            var helper = new IconFocusableTagHelper(options);
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            AssertAttributeValue(output.Attributes, "focusable", "false");
+        }
+    }
+}

--- a/test/IconTagHelperTests.cs
+++ b/test/IconTagHelperTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
 
     using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -29,8 +30,8 @@
             // Then
             output.TagMode.ShouldBe(TagMode.StartTagAndEndTag);
             output.TagName.ShouldBe("svg");
-            output.Attributes.ShouldContain(new TagHelperAttribute("aria-hidden", "true"));
-            output.Attributes.ShouldContain(new TagHelperAttribute("viewbox", "0 0 24 24"));
+            AssertAttributeValue(output.Attributes, "aria-hidden", "true");
+            AssertAttributeValue(output.Attributes, "viewbox", "0 0 24 24");
         }
 
         [Theory]
@@ -46,16 +47,16 @@
             var options = Options.Create(new HeroiconOptions());
             var helper = new IconTagHelper(options)
             {
-                Icon = IconSymbol.Bell
+                Icon = IconSymbol.Bell,
             };
 
             // When
             helper.Process(context, output);
 
             // Then
-            output.Attributes.ShouldContain(new TagHelperAttribute("fill", "none"));
-            output.Attributes.ShouldContain(new TagHelperAttribute("stroke", "currentColor"));
-            output.Attributes.ShouldContain(new TagHelperAttribute("viewbox", "0 0 24 24"));
+            AssertAttributeValue(output.Attributes, "fill", "none");
+            AssertAttributeValue(output.Attributes, "stroke", "currentColor");
+            AssertAttributeValue(output.Attributes, "viewbox", "0 0 24 24");
             output.Content.GetContent().ShouldBe("<path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9\"/>");
         }
 
@@ -72,15 +73,15 @@
             var options = Options.Create(new HeroiconOptions());
             var helper = new IconTagHelper(options)
             {
-                Icon = IconSymbol.Bell
+                Icon = IconSymbol.Bell,
             };
 
             // When
             helper.Process(context, output);
 
             // Then
-            output.Attributes.ShouldContain(new TagHelperAttribute("fill", "currentColor"));
-            output.Attributes.ShouldContain(new TagHelperAttribute("viewbox", "0 0 20 20"));
+            AssertAttributeValue(output.Attributes, "fill", "currentColor");
+            AssertAttributeValue(output.Attributes, "viewbox", "0 0 20 20");
             output.Attributes.ShouldNotContain(a => a.Name == "stroke");
             output.Content.GetContent().ShouldBe("<path d=\"M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z\"/>");
         }
@@ -108,14 +109,14 @@
             var options = Options.Create(new HeroiconOptions());
             var helper = new IconTagHelper(options)
             {
-                Icon = IconSymbol.Bell
+                Icon = IconSymbol.Bell,
             };
 
             // When
             helper.Process(context, output);
 
             // Then
-            output.Attributes.ShouldContain(new TagHelperAttribute(attributeName, attributeValue));
+            AssertAttributeValue(output.Attributes, attributeName, attributeValue);
         }
 
         [Fact]
@@ -183,6 +184,15 @@
                 tagName,
                 attributes: attributes,
                 getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+        }
+
+        private static void AssertAttributeValue(TagHelperAttributeList attributes, string name, string value)
+        {
+            attributes
+                .Count(a => a.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                .ShouldBe(1);
+
+            attributes[name].Value.ShouldBe(value);
         }
     }
 }

--- a/test/IconTagHelperTests.cs
+++ b/test/IconTagHelperTests.cs
@@ -34,6 +34,76 @@
             AssertAttributeValue(output.Attributes, "viewbox", "0 0 24 24");
         }
 
+        [Fact]
+        public void Should_overwrite_existing_attributes_for_solid_style()
+        {
+            // Given
+            var context = MakeTagHelperContext(
+                tagName: "heroicon-solid",
+                new TagHelperAttributeList
+                {
+                    { "fill", "blue" },
+                    { "viewbox", "0 0 1 1" },
+                });
+            var output = MakeTagHelperOutput(
+                tagName: "heroicon-solid",
+                new TagHelperAttributeList
+                {
+                    { "fill", "blue" },
+                    { "viewbox", "0 0 1 1" },
+                });
+
+            var options = Options.Create(new HeroiconOptions());
+            var helper = new IconTagHelper(options)
+            {
+                Icon = IconSymbol.Bell,
+            };
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            AssertAttributeValue(output.Attributes, "fill", "currentColor");
+            AssertAttributeValue(output.Attributes, "viewbox", "0 0 20 20");
+            output.Attributes.ShouldNotContain(a => a.Name == "stroke");
+        }
+
+        [Fact]
+        public void Should_overwrite_existing_attributes_for_outline_style()
+        {
+            // Given
+            var context = MakeTagHelperContext(
+                tagName: "heroicon-outline",
+                new TagHelperAttributeList
+                {
+                    { "fill", "blue" },
+                    { "stroke", "blue" },
+                    { "viewbox", "0 0 1 1" },
+                });
+            var output = MakeTagHelperOutput(
+                tagName: "heroicon-outline",
+                new TagHelperAttributeList
+                {
+                    { "fill", "blue" },
+                    { "stroke", "blue" },
+                    { "viewbox", "0 0 1 1" },
+                });
+
+            var options = Options.Create(new HeroiconOptions());
+            var helper = new IconTagHelper(options)
+            {
+                Icon = IconSymbol.Bell,
+            };
+
+            // When
+            helper.Process(context, output);
+
+            // Then
+            AssertAttributeValue(output.Attributes, "fill", "none");
+            AssertAttributeValue(output.Attributes, "stroke", "currentColor");
+            AssertAttributeValue(output.Attributes, "viewbox", "0 0 24 24");
+        }
+
         [Theory]
         [InlineData("heroicon-outline")]
         [InlineData("Heroicon-Outline")]

--- a/test/IconTagHelperTests.cs
+++ b/test/IconTagHelperTests.cs
@@ -25,7 +25,6 @@
             // Then
             output.TagMode.ShouldBe(TagMode.StartTagAndEndTag);
             output.TagName.ShouldBe("svg");
-            AssertAttributeValue(output.Attributes, "aria-hidden", "true");
             AssertAttributeValue(output.Attributes, "viewbox", "0 0 24 24");
         }
 

--- a/test/IconTagHelperTests.cs
+++ b/test/IconTagHelperTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Tailwind.Heroicons
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     using Microsoft.AspNetCore.Razor.TagHelpers;
     using Microsoft.Extensions.Options;
 
@@ -12,14 +7,14 @@
 
     using Xunit;
 
-    public class IconTagHelperTests
+    public class IconTagHelperTests : TagHelperTestBase
     {
         [Fact]
         public void Should_set_svg_attributes()
         {
             // Given
-            var context = MakeTagHelperContext(tagName: "heroicon-outline");
-            var output = MakeTagHelperOutput(tagName: "heroicon-outline");
+            var context = MakeTagHelperContext("heroicon-outline");
+            var output = MakeTagHelperOutput("heroicon-outline");
 
             var options = Options.Create(new HeroiconOptions());
             var helper = new IconTagHelper(options);
@@ -39,14 +34,14 @@
         {
             // Given
             var context = MakeTagHelperContext(
-                tagName: "heroicon-solid",
+                "heroicon-solid",
                 new TagHelperAttributeList
                 {
                     { "fill", "blue" },
                     { "viewbox", "0 0 1 1" },
                 });
             var output = MakeTagHelperOutput(
-                tagName: "heroicon-solid",
+                "heroicon-solid",
                 new TagHelperAttributeList
                 {
                     { "fill", "blue" },
@@ -73,7 +68,7 @@
         {
             // Given
             var context = MakeTagHelperContext(
-                tagName: "heroicon-outline",
+                "heroicon-outline",
                 new TagHelperAttributeList
                 {
                     { "fill", "blue" },
@@ -81,7 +76,7 @@
                     { "viewbox", "0 0 1 1" },
                 });
             var output = MakeTagHelperOutput(
-                tagName: "heroicon-outline",
+                "heroicon-outline",
                 new TagHelperAttributeList
                 {
                     { "fill", "blue" },
@@ -164,13 +159,13 @@
         {
             // Given
             var context = MakeTagHelperContext(
-                tagName: "heroicon-solid",
+                "heroicon-solid",
                 new TagHelperAttributeList
                 {
                     { attributeName, attributeValue },
                 });
             var output = MakeTagHelperOutput(
-                tagName: "heroicon-solid",
+                "heroicon-solid",
                 new TagHelperAttributeList
                 {
                     { attributeName, attributeValue },
@@ -193,8 +188,8 @@
         public void Should_not_include_html_comment_when_IncludeComments_is_false()
         {
             // Given
-            var context = MakeTagHelperContext(tagName: "heroicon-outline");
-            var output = MakeTagHelperOutput(tagName: "heroicon-outline");
+            var context = MakeTagHelperContext("heroicon-outline");
+            var output = MakeTagHelperOutput("heroicon-outline");
 
             var options = Options.Create(new HeroiconOptions
             {
@@ -216,8 +211,8 @@
         public void Should_include_html_comment_when_IncludeComments_is_true()
         {
             // Given
-            var context = MakeTagHelperContext(tagName: "heroicon-outline");
-            var output = MakeTagHelperOutput(tagName: "heroicon-outline");
+            var context = MakeTagHelperContext("heroicon-outline");
+            var output = MakeTagHelperOutput("heroicon-outline");
 
             var options = Options.Create(new HeroiconOptions
             {
@@ -233,36 +228,6 @@
 
             // Then
             output.PreElement.GetContent().ShouldBe("<!-- Heroicon name: outline bell -->");
-        }
-
-        private static TagHelperContext MakeTagHelperContext(string tagName, TagHelperAttributeList attributes = null)
-        {
-            attributes ??= new TagHelperAttributeList();
-
-            return new TagHelperContext(
-                tagName,
-                allAttributes: attributes,
-                items: new Dictionary<object, object>(),
-                uniqueId: Guid.NewGuid().ToString("N"));
-        }
-
-        private static TagHelperOutput MakeTagHelperOutput(string tagName, TagHelperAttributeList attributes = null)
-        {
-            attributes ??= new TagHelperAttributeList();
-
-            return new TagHelperOutput(
-                tagName,
-                attributes: attributes,
-                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
-        }
-
-        private static void AssertAttributeValue(TagHelperAttributeList attributes, string name, string value)
-        {
-            attributes
-                .Count(a => a.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
-                .ShouldBe(1);
-
-            attributes[name].Value.ShouldBe(value);
         }
     }
 }

--- a/test/TagHelperTestBase.cs
+++ b/test/TagHelperTestBase.cs
@@ -1,0 +1,44 @@
+﻿namespace Tailwind.Heroicons
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+
+    using Shouldly;
+
+    public abstract class TagHelperTestBase
+    {
+        protected static TagHelperContext MakeTagHelperContext(string tagName, TagHelperAttributeList attributes = null)
+        {
+            attributes ??= new TagHelperAttributeList();
+
+            return new TagHelperContext(
+                tagName,
+                allAttributes: attributes,
+                items: new Dictionary<object, object>(),
+                uniqueId: Guid.NewGuid().ToString("N"));
+        }
+
+        protected static TagHelperOutput MakeTagHelperOutput(string tagName, TagHelperAttributeList attributes = null)
+        {
+            attributes ??= new TagHelperAttributeList();
+
+            return new TagHelperOutput(
+                tagName,
+                attributes: attributes,
+                getChildContentAsync: (useCachedResult, encoder) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+        }
+
+        protected static void AssertAttributeValue(TagHelperAttributeList attributes, string name, string value)
+        {
+            attributes
+                .Count(a => a.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                .ShouldBe(1);
+
+            attributes[name].Value.ShouldBe(value);
+        }
+    }
+}


### PR DESCRIPTION
Adds two settings that are opt-in which will add `focusable="false"` to the `svg` element, and set `aria-hidden="true"` or `role="img"` based on the values of the `aria-label` and `aria-labeledby` attributes.