### PR TITLE
Bump `heroicons` from 0.4.2 to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Bumped `heroicons` from 0.4.2 to 1.0.0
+
 ## v0.4.2
 
 - Set `heroicons` version to v0.4.2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>0.4.2</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Brian Surowiec</Authors>
   </PropertyGroup>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,25 @@
 {
   "name": "heroicons-tag-helper",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "heroicons": "1.0.0"
+      }
+    },
+    "node_modules/heroicons": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/heroicons/-/heroicons-1.0.0.tgz",
+      "integrity": "sha512-APdX3PsNWCaT08osUV0oIFOS0ly8jT+fFsqvriQcMsSjbhd3TZqVh/Wy1XuYaCDd8GzKdkjbfzuCJJMIP/Z88w==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "heroicons": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/heroicons/-/heroicons-0.4.2.tgz",
-      "integrity": "sha512-24Bc6LKmamKHzGiNC80/r9v/7pQrma2V5KlaLUHGoarqm+hggmxnngU+RjHQT8sANWPa5FWKLftn4fpmvry/7w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/heroicons/-/heroicons-1.0.0.tgz",
+      "integrity": "sha512-APdX3PsNWCaT08osUV0oIFOS0ly8jT+fFsqvriQcMsSjbhd3TZqVh/Wy1XuYaCDd8GzKdkjbfzuCJJMIP/Z88w==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "heroicons-tag-helper",
   "private": true,
   "devDependencies": {
-    "heroicons": "^0.4.2"
+    "heroicons": "1.0.0"
   }
 }


### PR DESCRIPTION
Manual version of #35 since dependabot changed the version when it rebased.