### PR TITLE
Move build scripts over to run-script

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "run-script": {
+      "version": "0.1.0-beta.2",
+      "commands": [
+        "r"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,13 @@ jobs:
 
       - run: npm ci
 
-      - run: dotnet build --configuration Release
+      - run: dotnet tool restore
 
-      - run: dotnet test --configuration Release --no-build --logger "trx" --results-directory "./.codecoverage"
+      - run: dotnet r build:release
 
-      - run: dotnet pack --configuration Release --output ./artifacts --version-suffix $VERSION_SUFFIX
+      - run: dotnet r test:release
+
+      - run: dotnet r pack:release -- --version-suffix $VERSION_SUFFIX
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3.0.0
@@ -60,7 +62,7 @@ jobs:
         if: always()
         with:
           name: test-results
-          path: ./.codecoverage/*.trx
+          path: ./.coverage/*.trx
 
       - name: Publish to GPR
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
           dotnet-version: |
             3.1.x
             5.0.x
+            6.0.x
 
-      - name: Set up .NET Core (global.json)
-        uses: actions/setup-dotnet@v2.0.0
+      #- name: Set up .NET Core (global.json)
+      #  uses: actions/setup-dotnet@v2.0.0
 
       - run: npm ci
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,11 +39,13 @@ jobs:
 
       - run: npm ci
 
-      - run: dotnet build --configuration Release
+      - run: dotnet tool restore
 
-      - run: dotnet test --configuration Release --no-build --logger "trx" --results-directory "./.codecoverage"
+      - run: dotnet r build:release
 
-      - run: dotnet pack --configuration Release --output ./artifacts --version-suffix $VERSION_SUFFIX
+      - run: dotnet r test:release
+
+      - run: dotnet r pack:release -- --version-suffix $VERSION_SUFFIX
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3.0.0
@@ -55,4 +57,4 @@ jobs:
         if: always()
         with:
           name: test-results
-          path: ./.codecoverage/*.trx
+          path: ./.coverage/*.trx

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,9 +33,10 @@ jobs:
           dotnet-version: |
             3.1.x
             5.0.x
+            6.0.x
 
-      - name: Set up .NET Core (global.json)
-        uses: actions/setup-dotnet@v2.0.0
+      #- name: Set up .NET Core (global.json)
+      #  uses: actions/setup-dotnet@v2.0.0
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,10 @@ jobs:
           dotnet-version: |
             3.1.x
             5.0.x
+            6.0.x
 
-      - name: Set up .NET Core (global.json)
-        uses: actions/setup-dotnet@v2.0.0
+      #- name: Set up .NET Core (global.json)
+      #  uses: actions/setup-dotnet@v2.0.0
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,13 @@ jobs:
 
       - run: npm ci
 
-      - run: dotnet build --configuration Release
+      - run: dotnet tool restore
 
-      - run: dotnet test --configuration Release --no-build --logger "trx" --results-directory "./.codecoverage"
+      - run: dotnet r build:release
 
-      - run: dotnet pack --configuration Release --output ./artifacts
+      - run: dotnet r test:release
+
+      - run: dotnet r pack:release
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3.0.0
@@ -55,7 +57,7 @@ jobs:
         if: always()
         with:
           name: test-results
-          path: ./.codecoverage/*.trx
+          path: ./.coverage/*.trx
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "files.associations" : {
+        "global.json" : "json5"
+    },
     "cSpell.words": [
         "evenodd",
         "heroicon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Target .NET Core 3.1, .NET 5.0, and .NET 6.0
+- Moved build scripts over to the [run-script](https://github.com/xt0rted/dotnet-run-script) dotnet tool
 
 ## [1.0.5](https://github.com/xt0rted/heroicons-tag-helper/compare/v1.0.4...v1.0.5) - 2021-11-07
 

--- a/README.md
+++ b/README.md
@@ -101,3 +101,8 @@ will output
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
 </svg>
 ```
+
+## Development
+
+This project uses the [run-script](https://github.com/xt0rted/dotnet-run-script) dotnet tool to manage its build and test scripts.
+To use this you'll need to run `dotnet tool install` and then `dotnet r` to see the available commands or look at the `scripts` section in the [global.json](global.json).

--- a/global.json
+++ b/global.json
@@ -1,5 +1,18 @@
 {
   "sdk": {
     "version": "6.0.201"
+  },
+  "scripts": {
+    // Debug mode scripts
+    "build": "dotnet build",
+    "test": "dotnet test --no-build --logger \"trx\" --results-directory \"./.coverage\"",
+    "pack": "dotnet pack --no-build --output ./artifacts",
+    "ci": "dotnet r build && dotnet r test && dotnet r pack",
+
+    // Release mode scripts
+    "build:release": "dotnet r build -- --configuration Release",
+    "test:release": "dotnet r test -- --configuration Release",
+    "pack:release": "dotnet r pack -- --configuration Release",
+    "ci:release": "dotnet r build:release && dotnet r test:release && dotnet r pack:release"
   }
 }


### PR DESCRIPTION
This comments out the setup-dotnet global.json step until https://github.com/actions/setup-dotnet/pull/257 is merged.