### PR TITLE
Bump heroicons from 1.0.6 to 2.0.3

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "r"
       ]
+    },
+    "rimraf": {
+      "version": "0.1.0",
+      "commands": [
+        "rimraf"
+      ]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## Unreleased
 
-> **Note**: This version drops support for .NET 5 which is no longer supported.
-
 > **Note**: Due to a number of missing/incorrectly named icons the following versions were skipped: v2.0.0, v2.0.1, v2.0.2
 
 - Bumped `heroicons` from 1.0.6 to 2.0.3 ([#186](https://github.com/xt0rted/heroicons-tag-helper/pull/186))
   - A lot of icons were renamed in this release, see the `Update icon names` section in the [2.0.0 release notes](https://github.com/tailwindlabs/heroicons/releases/tag/v2.0.0) for more details
   - The new mini variant is available using the tag name `heroicon-mini` which supports the same settings as the solid variant
+- Dropped support for .NET 5 which is no longer supported
 - Switched from [actions/setup-dotnet](https://github.com/actions/setup-dotnet) to [xt0rted/setup-dotnet](https://github.com/xt0rted/setup-dotnet)
 
 ## [1.0.6](https://github.com/xt0rted/heroicons-tag-helper/compare/v1.0.5...v1.0.6) - 2022-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 > **Note**: Due to a number of missing/incorrectly named icons the following versions were skipped: v2.0.0, v2.0.1, v2.0.2
 
 - Bumped `heroicons` from 1.0.6 to 2.0.3 ([#186](https://github.com/xt0rted/heroicons-tag-helper/pull/186))
+  - A lot of icons were renamed in this release, see the `Update icon names` section in the [2.0.0 release notes](https://github.com/tailwindlabs/heroicons/releases/tag/v2.0.0) for more details
   - The new mini variant is available using the tag name `heroicon-mini` which supports the same settings as the solid variant
 - Switched from [actions/setup-dotnet](https://github.com/actions/setup-dotnet) to [xt0rted/setup-dotnet](https://github.com/xt0rted/setup-dotnet)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## Unreleased
 
 > **Note**: This version drops support for .NET 5 which is no longer supported.
->
+
+> **Note**: Due to a number of missing/incorrectly named icons the following versions were skipped: v2.0.0, v2.0.1, v2.0.2
+
+- Bumped `heroicons` from 1.0.6 to 2.0.3 ([#186](https://github.com/xt0rted/heroicons-tag-helper/pull/186))
+  - The new mini variant is available using the tag name `heroicon-mini` which supports the same settings as the solid variant
 - Switched from [actions/setup-dotnet](https://github.com/actions/setup-dotnet) to [xt0rted/setup-dotnet](https://github.com/xt0rted/setup-dotnet)
 
 ## [1.0.6](https://github.com/xt0rted/heroicons-tag-helper/compare/v1.0.5...v1.0.6) - 2022-03-15

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.0.6</VersionPrefix>
+    <VersionPrefix>2.0.3</VersionPrefix>
     <Authors>Brian Surowiec</Authors>
   </PropertyGroup>
 

--- a/generator/IconDetails.cs
+++ b/generator/IconDetails.cs
@@ -1,17 +1,16 @@
-﻿namespace IconSourceGenerator
+﻿namespace IconSourceGenerator;
+
+internal class IconDetails
 {
-    internal class IconDetails
-    {
-        public string Path { get; set; }
+    public string Path { get; set; }
 
-        public string Name { get; set; }
+    public string Name { get; set; }
 
-        public string ClassName { get; set; }
+    public string ClassName { get; set; }
 
-        public string Style { get; set; }
+    public string Style { get; set; }
 
-        public bool UsesStroke { get; set; }
+    public bool UsesStroke { get; set; }
 
-        public AdditionalText File { get; set; }
-    }
+    public AdditionalText File { get; set; }
 }

--- a/generator/IconExtractor.cs
+++ b/generator/IconExtractor.cs
@@ -1,28 +1,27 @@
-﻿namespace IconSourceGenerator
+﻿namespace IconSourceGenerator;
+
+internal static class IconExtractor
 {
-    internal static class IconExtractor
+    public static string GetPaths(string icon)
     {
-        public static string GetPaths(string icon)
-        {
-            var lines = icon.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(path => path.Trim()).ToArray();
+        var lines = icon.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(path => path.Trim()).ToArray();
 
-            var paths = lines.Skip(1).Take(lines.Length - 2);
+        var paths = lines.Skip(1).Take(lines.Length - 2);
 
-            return string.Join("", paths);
-        }
+        return string.Join("", paths);
+    }
 
-        public static string GetViewBox(string icon)
-        {
-            var match = Regex.Match(icon, "viewBox=\"(?<viewbox>[^\"]+)\"", RegexOptions.Compiled);
+    public static string GetViewBox(string icon)
+    {
+        var match = Regex.Match(icon, "viewBox=\"(?<viewbox>[^\"]+)\"", RegexOptions.Compiled);
 
-            return match.Groups["viewbox"].Value;
-        }
+        return match.Groups["viewbox"].Value;
+    }
 
-        public static string GetStrokeWidth(string icon)
-        {
-            var match = Regex.Match(icon, "stroke-width=\"(?<width>[^\"]+)\"", RegexOptions.Compiled);
+    public static string GetStrokeWidth(string icon)
+    {
+        var match = Regex.Match(icon, "stroke-width=\"(?<width>[^\"]+)\"", RegexOptions.Compiled);
 
-            return match.Groups["width"].Value;
-        }
+        return match.Groups["width"].Value;
     }
 }

--- a/generator/IconSourceGenerator.cs
+++ b/generator/IconSourceGenerator.cs
@@ -1,169 +1,180 @@
-﻿namespace IconSourceGenerator
+﻿namespace IconSourceGenerator;
+
+[Generator]
+public class IconSourceGenerator : ISourceGenerator
 {
-    [Generator]
-    public class IconSourceGenerator : ISourceGenerator
-    {
-        private static readonly DiagnosticDescriptor _errorDescriptor = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor _errorDescriptor = new DiagnosticDescriptor(
 #pragma warning disable RS2008 // Enable analyzer release tracking
-            "SI0000",
+        "SI0000",
 #pragma warning restore RS2008 // Enable analyzer release tracking
-            "Error in the IconSourceGenerator generator",
-            "Error in the IconSourceGenerator generator: '{0}'",
-            "IconSourceGenerator",
-            DiagnosticSeverity.Error,
-            isEnabledByDefault: true);
+        "Error in the IconSourceGenerator generator",
+        "Error in the IconSourceGenerator generator: '{0}'",
+        "IconSourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 
-        public void Execute(GeneratorExecutionContext context)
-        {
-            try
-            {
-                ExecuteInternal(context);
-            }
-            catch (Exception ex)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(_errorDescriptor, Location.None, ex.ToString()));
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void ExecuteInternal(GeneratorExecutionContext context)
-        {
-            var icons = LoadIcons(context);
-
-            BuildSymbolEnum(context, icons);
-            BuildIconListClass(context, icons);
-        }
-
-        private Dictionary<string, List<IconDetails>> LoadIcons(GeneratorExecutionContext context) =>
-            context
-                .AdditionalFiles
-                .Where(at => at.Path.EndsWith(".svg", StringComparison.InvariantCultureIgnoreCase))
-                .Select(file =>
-                {
-                    var options = context.AnalyzerConfigOptions.GetOptions(file);
-                    if (!options.TryGetValue("build_metadata.AdditionalFiles.IconStyle", out var iconStyle))
-                    {
-                        throw new Exception($"IconStyle not specified for file {file.Path}");
-                    }
-
-                    context.AnalyzerConfigOptions.GetOptions(file).TryGetValue("build_metadata.AdditionalFiles.UsesStroke", out var usesStrokeValue);
-                    bool.TryParse(usesStrokeValue, out var usesStroke);
-
-                    var directory = Path.GetDirectoryName(file.Path);
-                    var name = Path.GetFileNameWithoutExtension(file.Path);
-
-                    return new IconDetails
-                    {
-                        ClassName = name.ToPascalCase(),
-                        File = file,
-                        Name = name,
-                        Path = file.Path,
-                        Style = iconStyle,
-                        UsesStroke = usesStroke,
-                    };
-                })
-                .OrderBy(o => o.Style).ThenBy(o => o.Name)
-                .GroupBy(g => g.Style)
-                .ToDictionary(k => k.Key, k => k.ToList());
-
-        private void BuildSymbolEnum(GeneratorExecutionContext context, Dictionary<string, List<IconDetails>> icons)
-        {
-            var source = new StringBuilder(@"
-namespace Tailwind.Heroicons
-{
-    public enum IconSymbol
+    public void Execute(GeneratorExecutionContext context)
     {
-");
-
-            foreach (var icon in icons.First().Value)
-            {
-                source.AppendLine("        /// <summary>");
-                source.Append("        /// Heroicon name: ").AppendLine(icon.Name);
-                source.AppendLine("        /// </summary>");
-                source.Append("        ").Append(icon.ClassName).AppendLine(",");
-            }
-
-            source.AppendLine(@"
+        try
+        {
+            ExecuteInternal(context);
+        }
+        catch (Exception ex)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(_errorDescriptor, Location.None, ex.ToString()));
+        }
     }
-}");
 
-            context.AddSource("IconSymbolEnum", SourceText.From(source.ToString(), Encoding.UTF8));
-        }
-
-        private void BuildIconListClass(GeneratorExecutionContext context, Dictionary<string, List<IconDetails>> icons)
-        {
-            var source = new StringBuilder(@"
-namespace Tailwind.Heroicons
-{
-    using System;
-
-    public static class IconList
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ExecuteInternal(GeneratorExecutionContext context)
     {
-");
+        var icons = LoadIcons(context);
 
-            foreach (var style in icons)
+        BuildSymbolEnum(context, icons);
+        BuildIconListClass(context, icons);
+    }
+
+    private Dictionary<string, List<IconDetails>> LoadIcons(GeneratorExecutionContext context) =>
+        context
+            .AdditionalFiles
+            .Where(at => at.Path.EndsWith(".svg", StringComparison.InvariantCultureIgnoreCase))
+            .Select(file =>
             {
-                source.Append("        public static Icon ");
-                source.Append(style.Key.FirstCharToUpper());
-                source.Append("(IconSymbol symbol");
-                source.AppendLine(@")
-        {
-            switch (symbol)
-            {");
-
-                foreach (var icon in style.Value)
+                var options = context.AnalyzerConfigOptions.GetOptions(file);
+                if (!options.TryGetValue("build_metadata.AdditionalFiles.IconStyle", out var iconStyle))
                 {
-                    var file = icon.File.GetText(context.CancellationToken).ToString();
-                    var path = IconExtractor.GetPaths(file);
-                    var viewBox = IconExtractor.GetViewBox(file);
-
-                    // Escape the path string before writing it out
-                    path = path.Replace("\"", "\\\"");
-
-                    source.Append("                case IconSymbol.").Append(icon.ClassName).AppendLine(":");
-                    source.AppendLine("                    return new Icon");
-                    source.AppendLine("                    {");
-                    source.Append("                        Name = \"").Append(icon.Name).AppendLine("\",");
-                    source.Append("                        Path = \"").Append(path).AppendLine("\",");
-                    source.Append("                        ViewBox = \"").Append(viewBox).AppendLine("\",");
-
-                    if (icon.UsesStroke)
-                    {
-                        var strokeWidth = IconExtractor.GetStrokeWidth(file);
-
-                        source.Append("                        StrokeWidth = \"").Append(strokeWidth).AppendLine("\",");
-                    }
-
-                    source.AppendLine("                    };");
-                    source.AppendLine("");
+                    throw new Exception($"IconStyle not specified for file {file.Path}");
                 }
 
-                source.AppendLine(@"
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(symbol), symbol, ""Unsupported icon name"");
-            }
-        }");
-            }
+                context.AnalyzerConfigOptions.GetOptions(file).TryGetValue("build_metadata.AdditionalFiles.UsesStroke", out var usesStrokeValue);
+                bool.TryParse(usesStrokeValue, out var usesStroke);
 
-            source.AppendLine(@"
-    }
+                var directory = Path.GetDirectoryName(file.Path);
+                var name = Path.GetFileNameWithoutExtension(file.Path);
 
-    public class Icon
+                return new IconDetails
+                {
+                    ClassName = name.ToPascalCase(),
+                    File = file,
+                    Name = name,
+                    Path = file.Path,
+                    Style = iconStyle,
+                    UsesStroke = usesStroke,
+                };
+            })
+            .OrderBy(o => o.Style).ThenBy(o => o.Name)
+            .GroupBy(g => g.Style)
+            .ToDictionary(k => k.Key, k => k.ToList());
+
+    private void BuildSymbolEnum(GeneratorExecutionContext context, Dictionary<string, List<IconDetails>> icons)
     {
-        public string Name { get; set; }
-        public string Path { get; set; }
-        public string ViewBox { get; set; }
-        public string StrokeWidth { get; set; }
-    }
-}
-");
+        var source = new StringBuilder(
+            """
+            namespace Tailwind.Heroicons
+            {
+                public enum IconSymbol
+                {
 
-            context.AddSource("IconListClass", SourceText.From(source.ToString(), Encoding.UTF8));
-        }
+            """);
 
-        public void Initialize(GeneratorInitializationContext context)
+        foreach (var icon in icons.First().Value)
         {
-            // System.Diagnostics.Debugger.Launch();
+            source.AppendLine("        /// <summary>");
+            source.Append("        /// Heroicon name: ").AppendLine(icon.Name);
+            source.AppendLine("        /// </summary>");
+            source.Append("        ").Append(icon.ClassName).AppendLine(",");
         }
+
+        source.AppendLine(
+            """
+                }
+            }
+            """);
+
+        context.AddSource("IconSymbolEnum", SourceText.From(source.ToString(), Encoding.UTF8));
+    }
+
+    private void BuildIconListClass(GeneratorExecutionContext context, Dictionary<string, List<IconDetails>> icons)
+    {
+        var source = new StringBuilder(
+            """
+            namespace Tailwind.Heroicons
+            {
+                using System;
+
+                public static class IconList
+                {
+
+            """);
+
+        foreach (var style in icons)
+        {
+            source.Append("        public static Icon ");
+            source.Append(style.Key.FirstCharToUpper());
+            source.Append("(IconSymbol symbol");
+            source.AppendLine(
+                """
+                )
+                        {
+                            switch (symbol)
+                            {
+                """);
+
+            foreach (var icon in style.Value)
+            {
+                var file = icon.File.GetText(context.CancellationToken).ToString();
+                var path = IconExtractor.GetPaths(file);
+                var viewBox = IconExtractor.GetViewBox(file);
+
+                // Escape the path string before writing it out
+                path = path.Replace("\"", "\\\"");
+
+                source.Append("                case IconSymbol.").Append(icon.ClassName).AppendLine(":");
+                source.AppendLine("                    return new Icon");
+                source.AppendLine("                    {");
+                source.Append("                        Name = \"").Append(icon.Name).AppendLine("\",");
+                source.Append("                        Path = \"").Append(path).AppendLine("\",");
+                source.Append("                        ViewBox = \"").Append(viewBox).AppendLine("\",");
+
+                if (icon.UsesStroke)
+                {
+                    var strokeWidth = IconExtractor.GetStrokeWidth(file);
+
+                    source.Append("                        StrokeWidth = \"").Append(strokeWidth).AppendLine("\",");
+                }
+
+                source.AppendLine("                    };");
+                source.AppendLine("");
+            }
+
+            source.AppendLine(
+                """
+                                default:
+                                    throw new ArgumentOutOfRangeException(nameof(symbol), symbol, "Unsupported icon name");
+                            }
+                        }
+                """);
+        }
+
+        source.AppendLine(
+            """
+                }
+
+                public class Icon
+                {
+                    public string Name { get; set; }
+                    public string Path { get; set; }
+                    public string ViewBox { get; set; }
+                    public string StrokeWidth { get; set; }
+                }
+            }
+            """);
+
+        context.AddSource("IconListClass", SourceText.From(source.ToString(), Encoding.UTF8));
+    }
+
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        // System.Diagnostics.Debugger.Launch();
     }
 }

--- a/generator/StringExtensions.cs
+++ b/generator/StringExtensions.cs
@@ -1,26 +1,25 @@
-﻿namespace IconSourceGenerator
+﻿namespace IconSourceGenerator;
+
+internal static class StringExtensions
 {
-    internal static class StringExtensions
+    public static string FirstCharToUpper(this string input)
     {
-        public static string FirstCharToUpper(this string input)
+        var arr = input.ToCharArray();
+
+        arr[0] = char.ToUpperInvariant(arr[0]);
+
+        return new string(arr);
+    }
+
+    public static string ToPascalCase(this string name)
+    {
+        var splitName = name.Split('-');
+
+        for (var i = 0; i < splitName.Length; i++)
         {
-            var arr = input.ToCharArray();
-
-            arr[0] = char.ToUpperInvariant(arr[0]);
-
-            return new string(arr);
+            splitName[i] = FirstCharToUpper(splitName[i]);
         }
 
-        public static string ToPascalCase(this string name)
-        {
-            var splitName = name.Split('-');
-
-            for (var i = 0; i < splitName.Length; i++)
-            {
-                splitName[i] = FirstCharToUpper(splitName[i]);
-            }
-
-            return string.Join(string.Empty, splitName);
-        }
+        return string.Join(string.Empty, splitName);
     }
 }

--- a/global.json
+++ b/global.json
@@ -13,6 +13,7 @@
     "test:6": "dotnet r test -- --framework net6.0",
     "pack": "dotnet pack --no-build --output ./artifacts",
     "ci": "dotnet r build && dotnet r test && dotnet r pack",
+    "sample": "dotnet watch [env:DOTNET_WATCH_RESTART_ON_RUDE_EDIT=true] --verbose --project sample",
 
     // Release mode scripts
     "build:release": "dotnet r build -- --configuration Release",

--- a/global.json
+++ b/global.json
@@ -3,9 +3,14 @@
     "version": "6.0.401"
   },
   "scripts": {
+    "clean": "dotnet rimraf artifacts",
+    "clean:bin": "dotnet rimraf **/bin **/obj",
+
     // Debug mode scripts
     "build": "dotnet build",
-    "test": "dotnet test --no-build --logger \"trx\" --results-directory \"./.coverage\"",
+    "test": "dotnet test --logger \"trx\" --results-directory \"./.coverage\"",
+    "test:31": "dotnet r test -- --framework netcoreapp3.1",
+    "test:6": "dotnet r test -- --framework net6.0",
     "pack": "dotnet pack --no-build --output ./artifacts",
     "ci": "dotnet r build && dotnet r test && dotnet r pack",
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,22 +4,23 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "heroicons-tag-helper",
       "devDependencies": {
-        "heroicons": "1.0.6"
+        "heroicons": "2.0.3"
       }
     },
     "node_modules/heroicons": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/heroicons/-/heroicons-1.0.6.tgz",
-      "integrity": "sha512-5bxTsG2hyNBF0l+BrFlZlR5YngQNMfl0ggJjIRkMSADBQbaZMoTg47OIQzq6f1mpEZ85HEIgSC4wt5AeFM9J2Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/heroicons/-/heroicons-2.0.3.tgz",
+      "integrity": "sha512-cqzJ3K21nCRjq2gsvsJsFnuBcF8dKxNBxMy9PTQLT8xLDjjKJpoXimIN4qic+utCajxSn1VM5av+vTAWbfzHLA==",
       "dev": true
     }
   },
   "dependencies": {
     "heroicons": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/heroicons/-/heroicons-1.0.6.tgz",
-      "integrity": "sha512-5bxTsG2hyNBF0l+BrFlZlR5YngQNMfl0ggJjIRkMSADBQbaZMoTg47OIQzq6f1mpEZ85HEIgSC4wt5AeFM9J2Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/heroicons/-/heroicons-2.0.3.tgz",
+      "integrity": "sha512-cqzJ3K21nCRjq2gsvsJsFnuBcF8dKxNBxMy9PTQLT8xLDjjKJpoXimIN4qic+utCajxSn1VM5av+vTAWbfzHLA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "heroicons-tag-helper",
   "private": true,
   "devDependencies": {
-    "heroicons": "1.0.6"
+    "heroicons": "2.0.3"
   }
 }

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks></TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <Using Remove="System.Net.Http.Json" />
   </ItemGroup>

--- a/sample/Views/Home/Index.cshtml
+++ b/sample/Views/Home/Index.cshtml
@@ -1,5 +1,8 @@
 ﻿<div>
     <div class="p-4">
+        <h2>
+            Outline/Solid
+        </h2>
         <div class="flex justify-center items-end">
             <heroicon-outline icon="Sun" aria-label="The sun" class="w-6 text-red-500" />
             <heroicon-outline icon="Sun" aria-label="The sun" class="w-8 text-orange-500" />
@@ -40,6 +43,9 @@
         </div>
     </div>
     <div class="p-4 bg-black">
+        <h2 class="text-white">
+            Outline/Solid
+        </h2>
         <div class="flex justify-center items-end">
             <heroicon-outline icon="Star" class="w-6 text-red-500" />
             <heroicon-outline icon="Star" class="w-8 text-orange-500" />
@@ -80,6 +86,9 @@
         </div>
     </div>
     <div class="p-4">
+        <h2>
+            Outline with stroke-width attribute
+        </h2>
         <div class="flex justify-center items-end">
             <heroicon-outline icon="ArrowUp" stroke-width="0.5" class="w-6 text-red-500" />
             <heroicon-outline icon="ArrowUp" stroke-width="1" class="w-8 text-orange-500" />
@@ -120,6 +129,9 @@
         </div>
     </div>
     <div class="p-4 bg-black">
+        <h2 class="text-white">
+            Outline with stroke class
+        </h2>
         <div class="flex justify-center items-end">
             <heroicon-outline icon="ArrowDown" class="w-6 text-red-500 stroke-[0.5]" />
             <heroicon-outline icon="ArrowDown" class="w-8 text-orange-500 stroke-[1]" />
@@ -157,6 +169,92 @@
             <heroicon-outline icon="ArrowUp" class="w-10 text-yellow-500 stroke-[7.5]" />
             <heroicon-outline icon="ArrowUp" class="w-8 text-orange-500 stroke-[8]" />
             <heroicon-outline icon="ArrowUp" class="w-6 text-red-500 stroke-[8.5]" />
+        </div>
+    </div>
+    <div class="p-4">
+        <h2>
+            Solid/Mini
+        </h2>
+        <div class="flex justify-center items-end">
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-6 text-red-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-8 text-orange-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-10 text-yellow-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-12 text-green-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-16 text-teal-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-20 text-blue-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-24 text-indigo-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-32 text-purple-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-40 text-pink-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-32 text-purple-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-24 text-indigo-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-20 text-blue-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-16 text-teal-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-12 text-green-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-10 text-yellow-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-8 text-orange-500" />
+            <heroicon-solid icon="Banknotes" aria-label="Bank notes" class="w-6 text-red-500" />
+        </div>
+        <div class="mt-2 flex justify-center items-start">
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-6 text-red-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-8 text-orange-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-10 text-yellow-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-12 text-green-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-16 text-teal-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-20 text-blue-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-24 text-indigo-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-32 text-purple-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-40 text-pink-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-32 text-purple-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-24 text-indigo-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-20 text-blue-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-16 text-teal-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-12 text-green-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-10 text-yellow-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-8 text-orange-500" />
+            <heroicon-mini icon="Banknotes" aria-label="Bank notes" class="w-6 text-red-500" />
+        </div>
+    </div>
+    <div class="p-4 bg-black">
+        <h2 class="text-white">
+            Solid/Mini
+        </h2>
+        <div class="flex justify-center items-end">
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-6 text-red-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-8 text-orange-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-10 text-yellow-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-12 text-green-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-16 text-teal-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-20 text-blue-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-24 text-indigo-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-32 text-purple-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-40 text-pink-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-32 text-purple-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-24 text-indigo-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-20 text-blue-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-16 text-teal-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-12 text-green-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-10 text-yellow-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-8 text-orange-500" />
+            <heroicon-solid icon="CreditCard" aria-label="Credit card" class="w-6 text-red-500" />
+        </div>
+        <div class="mt-2 flex justify-center items-start">
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-6 text-red-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-8 text-orange-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-10 text-yellow-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-12 text-green-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-16 text-teal-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-20 text-blue-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-24 text-indigo-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-32 text-purple-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-40 text-pink-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-32 text-purple-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-24 text-indigo-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-20 text-blue-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-16 text-teal-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-12 text-green-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-10 text-yellow-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-8 text-orange-500" />
+            <heroicon-mini icon="CreditCard" aria-label="Credit card" class="w-6 text-red-500" />
         </div>
     </div>
 </div>

--- a/src/HeroiconOptions.cs
+++ b/src/HeroiconOptions.cs
@@ -1,23 +1,22 @@
-﻿namespace Tailwind.Heroicons
+﻿namespace Tailwind.Heroicons;
+
+public class HeroiconOptions
 {
-    public class HeroiconOptions
-    {
-        /// <summary>
-        /// Add an html comment before the svg tag with the style and name of the icon to help make development/debugging easier.
-        /// </summary>
-        /// <remarks>This is off by default.</remarks>
-        public bool IncludeComments { get; set; }
+    /// <summary>
+    /// Add an html comment before the svg tag with the style and name of the icon to help make development/debugging easier.
+    /// </summary>
+    /// <remarks>This is off by default.</remarks>
+    public bool IncludeComments { get; set; }
 
-        /// <summary>
-        /// Adds various accessibility attributes based on the default state of the tag.
-        /// </summary>
-        /// <remarks>This is off by default.</remarks>
-        public bool SetAccessibilityAttributes { get; set; }
+    /// <summary>
+    /// Adds various accessibility attributes based on the default state of the tag.
+    /// </summary>
+    /// <remarks>This is off by default.</remarks>
+    public bool SetAccessibilityAttributes { get; set; }
 
-        /// <summary>
-        /// Adds the <c>focusable</c> attribute set to <c>false</c> to prevent the icon from receiving focus in Internet Explorer and Edge Legacy.
-        /// </summary>
-        /// <remarks>This is off by default.</remarks>
-        public bool SetFocusableAttribute { get; set; }
-    }
+    /// <summary>
+    /// Adds the <c>focusable</c> attribute set to <c>false</c> to prevent the icon from receiving focus in Internet Explorer and Edge Legacy.
+    /// </summary>
+    /// <remarks>This is off by default.</remarks>
+    public bool SetFocusableAttribute { get; set; }
 }

--- a/src/HeroiconsExtensions.cs
+++ b/src/HeroiconsExtensions.cs
@@ -1,25 +1,24 @@
-﻿namespace Microsoft.Extensions.DependencyInjection
+﻿namespace Microsoft.Extensions.DependencyInjection;
+
+public static class HeroiconsExtensions
 {
-    public static class HeroiconsExtensions
+    public static IServiceCollection AddHeroicons(this IServiceCollection services, IConfiguration configuration)
     {
-        public static IServiceCollection AddHeroicons(this IServiceCollection services, IConfiguration configuration)
-        {
-            if (services is null) throw new ArgumentNullException(nameof(services));
-            if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+        if (services is null) throw new ArgumentNullException(nameof(services));
+        if (configuration is null) throw new ArgumentNullException(nameof(configuration));
 
-            services.Configure<HeroiconOptions>(configuration.GetSection("Heroicons"));
+        services.Configure<HeroiconOptions>(configuration.GetSection("Heroicons"));
 
-            return services;
-        }
+        return services;
+    }
 
-        public static IServiceCollection AddHeroicons(this IServiceCollection services, Action<HeroiconOptions> configureOptions)
-        {
-            if (services is null) throw new ArgumentNullException(nameof(services));
-            if (configureOptions is null) throw new ArgumentNullException(nameof(configureOptions));
+    public static IServiceCollection AddHeroicons(this IServiceCollection services, Action<HeroiconOptions> configureOptions)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+        if (configureOptions is null) throw new ArgumentNullException(nameof(configureOptions));
 
-            services.Configure(configureOptions);
+        services.Configure(configureOptions);
 
-            return services;
-        }
+        return services;
     }
 }

--- a/src/HeroiconsTagHelper.csproj
+++ b/src/HeroiconsTagHelper.csproj
@@ -32,11 +32,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="../node_modules/heroicons/outline/*.svg" IconStyle="outline" UsesStroke="true">
+    <AdditionalFiles Include="../node_modules/heroicons/24/outline/*.svg" IconStyle="outline" UsesStroke="true">
       <LinkBase>icons/outline</LinkBase>
     </AdditionalFiles>
-    <AdditionalFiles Include="../node_modules/heroicons/solid/*.svg" IconStyle="solid">
+    <AdditionalFiles Include="../node_modules/heroicons/24/solid/*.svg" IconStyle="solid">
       <LinkBase>icons/solid</LinkBase>
+    </AdditionalFiles>
+    <AdditionalFiles Include="../node_modules/heroicons/20/solid/*.svg" IconStyle="mini">
+      <LinkBase>icons/mini</LinkBase>
     </AdditionalFiles>
   </ItemGroup>
 

--- a/src/IconAccessibilityTagHelper.cs
+++ b/src/IconAccessibilityTagHelper.cs
@@ -1,43 +1,42 @@
-﻿namespace Tailwind.Heroicons
-{
-    [HtmlTargetElement("heroicon-outline")]
-    [HtmlTargetElement("heroicon-solid")]
-    public class IconAccessibilityTagHelper : TagHelper
-    {
-        private readonly HeroiconOptions _settings;
+﻿namespace Tailwind.Heroicons;
 
-        public IconAccessibilityTagHelper(IOptions<HeroiconOptions> settings)
+[HtmlTargetElement("heroicon-outline")]
+[HtmlTargetElement("heroicon-solid")]
+public class IconAccessibilityTagHelper : TagHelper
+{
+    private readonly HeroiconOptions _settings;
+
+    public IconAccessibilityTagHelper(IOptions<HeroiconOptions> settings)
+    {
+        _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    public override int Order => 1000;
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (context is null) throw new ArgumentNullException(nameof(context));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+
+        if (!_settings.SetAccessibilityAttributes)
         {
-            _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+            return;
         }
 
-        public override int Order => 1000;
+        var ariaLabel = output.Attributes["aria-label"]?.ToStringValue();
+        var ariaLabeledBy = output.Attributes["aria-labeledby"]?.ToStringValue();
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        var isUsedAsImage =
+            !string.IsNullOrWhiteSpace(ariaLabel) ||
+            !string.IsNullOrWhiteSpace(ariaLabeledBy);
+
+        if (isUsedAsImage)
         {
-            if (context is null) throw new ArgumentNullException(nameof(context));
-            if (output is null) throw new ArgumentNullException(nameof(output));
-
-            if (!_settings.SetAccessibilityAttributes)
-            {
-                return;
-            }
-
-            var ariaLabel = output.Attributes["aria-label"]?.ToStringValue();
-            var ariaLabeledBy = output.Attributes["aria-labeledby"]?.ToStringValue();
-
-            var isUsedAsImage =
-                !string.IsNullOrWhiteSpace(ariaLabel) ||
-                !string.IsNullOrWhiteSpace(ariaLabeledBy);
-
-            if (isUsedAsImage)
-            {
-                output.Attributes.SetAttribute("role", "img");
-            }
-            else
-            {
-                output.Attributes.SetAttribute("aria-hidden", "true");
-            }
+            output.Attributes.SetAttribute("role", "img");
+        }
+        else
+        {
+            output.Attributes.SetAttribute("aria-hidden", "true");
         }
     }
 }

--- a/src/IconFocusableTagHelper.cs
+++ b/src/IconFocusableTagHelper.cs
@@ -1,29 +1,28 @@
-﻿namespace Tailwind.Heroicons
+﻿namespace Tailwind.Heroicons;
+
+[HtmlTargetElement("heroicon-outline")]
+[HtmlTargetElement("heroicon-solid")]
+public class IconFocusableTagHelper : TagHelper
 {
-    [HtmlTargetElement("heroicon-outline")]
-    [HtmlTargetElement("heroicon-solid")]
-    public class IconFocusableTagHelper : TagHelper
+    private readonly HeroiconOptions _settings;
+
+    public IconFocusableTagHelper(IOptions<HeroiconOptions> settings)
     {
-        private readonly HeroiconOptions _settings;
+        _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+    }
 
-        public IconFocusableTagHelper(IOptions<HeroiconOptions> settings)
+    public override int Order => 1000;
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (context is null) throw new ArgumentNullException(nameof(context));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+
+        if (!_settings.SetFocusableAttribute)
         {
-            _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+            return;
         }
 
-        public override int Order => 1000;
-
-        public override void Process(TagHelperContext context, TagHelperOutput output)
-        {
-            if (context is null) throw new ArgumentNullException(nameof(context));
-            if (output is null) throw new ArgumentNullException(nameof(output));
-
-            if (!_settings.SetFocusableAttribute)
-            {
-                return;
-            }
-
-            output.Attributes.SetAttribute("focusable", "false");
-        }
+        output.Attributes.SetAttribute("focusable", "false");
     }
 }

--- a/src/IconTagHelper.cs
+++ b/src/IconTagHelper.cs
@@ -1,61 +1,80 @@
-﻿namespace Tailwind.Heroicons
+﻿namespace Tailwind.Heroicons;
+
+
+[HtmlTargetElement("heroicon-mini", TagStructure = TagStructure.WithoutEndTag)]
+[HtmlTargetElement("heroicon-outline", TagStructure = TagStructure.WithoutEndTag)]
+[HtmlTargetElement("heroicon-solid", TagStructure = TagStructure.WithoutEndTag)]
+public class IconTagHelper : TagHelper
 {
-    [HtmlTargetElement("heroicon-outline", TagStructure = TagStructure.WithoutEndTag)]
-    [HtmlTargetElement("heroicon-solid", TagStructure = TagStructure.WithoutEndTag)]
-    public class IconTagHelper : TagHelper
+    private readonly HeroiconOptions _settings;
+
+    public IconTagHelper(IOptions<HeroiconOptions> settings)
     {
-        private readonly HeroiconOptions _settings;
+        _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+    }
 
-        public IconTagHelper(IOptions<HeroiconOptions> settings)
-        {
-            _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
-        }
+    public override int Order => 0;
 
-        public override int Order => 0;
+    [HtmlAttributeName("icon")]
+    public IconSymbol Icon { get; set; }
 
-        [HtmlAttributeName("icon")]
-        public IconSymbol Icon { get; set; }
+    [HtmlAttributeName("stroke-width")]
+    public string StrokeWidth { get; set; }
 
-        [HtmlAttributeName("stroke-width")]
-        public string StrokeWidth { get; set; }
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (context is null) throw new ArgumentNullException(nameof(context));
+        if (output is null) throw new ArgumentNullException(nameof(output));
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
-        {
-            if (context is null) throw new ArgumentNullException(nameof(context));
-            if (output is null) throw new ArgumentNullException(nameof(output));
+        var isMini = context.TagName.Equals("heroicon-mini", StringComparison.OrdinalIgnoreCase);
+        var isSolid = context.TagName.Equals("heroicon-solid", StringComparison.OrdinalIgnoreCase);
 
-            var isSolid = context.TagName.Equals("heroicon-solid", StringComparison.OrdinalIgnoreCase);
-
-            var icon = isSolid
+        var icon = isMini
+            ? IconList.Mini(Icon)
+            : isSolid
                 ? IconList.Solid(Icon)
                 : IconList.Outline(Icon);
 
-            output.TagMode = TagMode.StartTagAndEndTag;
-            output.TagName = "svg";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.TagName = "svg";
 
-            if (isSolid)
-            {
-                output.Attributes.SetAttribute("fill", "currentColor");
-            }
-            else
-            {
-                output.Attributes.SetAttribute("fill", "none");
-                output.Attributes.SetAttribute("stroke", "currentColor");
-                output.Attributes.SetAttribute("stroke-width", StrokeWidth ?? icon.StrokeWidth);
-            }
-
-            output.Attributes.SetAttribute("viewbox", icon.ViewBox);
-
-            output.Content.AppendHtml(icon.Path);
-
-            if (_settings.IncludeComments)
-            {
-                output.PreElement.AppendHtml("<!-- Heroicon name: ");
-                output.PreElement.AppendHtml(isSolid ? "solid" : "outline");
-                output.PreElement.AppendHtml(" ");
-                output.PreElement.Append(icon.Name);
-                output.PreElement.AppendHtml(" -->");
-            }
+        if (isMini || isSolid)
+        {
+            output.Attributes.SetAttribute("fill", "currentColor");
         }
+        else
+        {
+            output.Attributes.SetAttribute("fill", "none");
+            output.Attributes.SetAttribute("stroke", "currentColor");
+            output.Attributes.SetAttribute("stroke-width", StrokeWidth ?? icon.StrokeWidth);
+        }
+
+        output.Attributes.SetAttribute("viewbox", icon.ViewBox);
+
+        output.Content.AppendHtml(icon.Path);
+
+        if (_settings.IncludeComments)
+        {
+            output.PreElement.AppendHtml("<!-- Heroicon name: ");
+            output.PreElement.Append(IconStyle(isMini, isSolid));
+            output.PreElement.Append(" ");
+            output.PreElement.Append(icon.Name);
+            output.PreElement.AppendHtmlLine(" -->");
+        }
+    }
+
+    private static string IconStyle(bool isMini, bool isSolid)
+    {
+        if (isMini)
+        {
+            return "mini";
+        }
+
+        if (isSolid)
+        {
+            return "solid";
+        }
+
+        return "outline";
     }
 }

--- a/src/TagHelperAttributeExtensions.cs
+++ b/src/TagHelperAttributeExtensions.cs
@@ -1,13 +1,12 @@
-﻿namespace Tailwind.Heroicons
+﻿namespace Tailwind.Heroicons;
+
+internal static class TagHelperAttributeExtensions
 {
-    internal static class TagHelperAttributeExtensions
-    {
-        public static string ToStringValue(this TagHelperAttribute attribute) =>
-            attribute.Value switch
-            {
-                HtmlString htmlString => htmlString.ToString(),
-                string stringValue => stringValue,
-                _ => null,
-            };
-    }
+    public static string ToStringValue(this TagHelperAttribute attribute) =>
+        attribute.Value switch
+        {
+            HtmlString htmlString => htmlString.ToString(),
+            string stringValue => stringValue,
+            _ => null,
+        };
 }

--- a/test/IconListTests.cs
+++ b/test/IconListTests.cs
@@ -3,26 +3,32 @@
     public class IconListTests
     {
         [Fact]
-        public void Should_return_the_ArrowCircleDown_icon_in_the_outline_style()
+        public void Should_return_the_ArrowDownCircle_icon_in_the_outline_style()
         {
             // Given / When
-            var icon = IconList.Outline(IconSymbol.ArrowCircleDown);
+            var icon = IconList.Outline(IconSymbol.ArrowDownCircle);
 
             // Then
-            icon.Path.ShouldBe("<path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M15 13l-3 3m0 0l-3-3m3 3V8m0 13a9 9 0 110-18 9 9 0 010 18z\"/>");
+            icon.Path.ShouldBe(
+                """
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75l3 3m0 0l3-3m-3 3v-7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                """);
             icon.ViewBox.ShouldBe("0 0 24 24");
-            icon.StrokeWidth.ShouldBe("2");
+            icon.StrokeWidth.ShouldBe("1.5");
         }
 
         [Fact]
-        public void Should_return_the_ArrowCircleDown_icon_in_the_solid_style()
+        public void Should_return_the_ArrowDownCircle_icon_in_the_solid_style()
         {
             // Given
-            var icon = IconList.Solid(IconSymbol.ArrowCircleDown);
+            var icon = IconList.Solid(IconSymbol.ArrowDownCircle);
 
             // When / Then
-            icon.Path.ShouldBe("<path fill-rule=\"evenodd\" d=\"M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v3.586L7.707 9.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 10.586V7z\" clip-rule=\"evenodd\"/>");
-            icon.ViewBox.ShouldBe("0 0 20 20");
+            icon.Path.ShouldBe(
+                """
+                <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-.53 14.03a.75.75 0 001.06 0l3-3a.75.75 0 10-1.06-1.06l-1.72 1.72V8.25a.75.75 0 00-1.5 0v5.69l-1.72-1.72a.75.75 0 00-1.06 1.06l3 3z" clip-rule="evenodd"/>
+                """);
+            icon.ViewBox.ShouldBe("0 0 24 24");
             icon.StrokeWidth.ShouldBeNull();
         }
     }

--- a/test/IconTagHelperTests.cs
+++ b/test/IconTagHelperTests.cs
@@ -51,7 +51,7 @@
 
             // Then
             AssertAttributeValue(output.Attributes, "fill", "currentColor");
-            AssertAttributeValue(output.Attributes, "viewbox", "0 0 20 20");
+            AssertAttributeValue(output.Attributes, "viewbox", "0 0 24 24");
             output.Attributes.ShouldNotContain(a => a.Name == "stroke");
         }
 
@@ -113,9 +113,12 @@
             // Then
             AssertAttributeValue(output.Attributes, "fill", "none");
             AssertAttributeValue(output.Attributes, "stroke", "currentColor");
-            AssertAttributeValue(output.Attributes, "stroke-width", "2");
+            AssertAttributeValue(output.Attributes, "stroke-width", "1.5");
             AssertAttributeValue(output.Attributes, "viewbox", "0 0 24 24");
-            output.Content.GetContent().ShouldBe("<path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9\"/>");
+            output.Content.GetContent().ShouldBe(
+                """
+                <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0"/>
+                """);
         }
 
         [Theory]
@@ -139,10 +142,13 @@
 
             // Then
             AssertAttributeValue(output.Attributes, "fill", "currentColor");
-            AssertAttributeValue(output.Attributes, "viewbox", "0 0 20 20");
+            AssertAttributeValue(output.Attributes, "viewbox", "0 0 24 24");
             output.Attributes.ShouldNotContain(a => a.Name == "stroke");
             output.Attributes.ShouldNotContain(a => a.Name == "stroke-width");
-            output.Content.GetContent().ShouldBe("<path d=\"M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z\"/>");
+            output.Content.GetContent().ShouldBe(
+                """
+                <path fill-rule="evenodd" d="M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 01-.297 1.206c-1.544.57-3.16.99-4.831 1.243a3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 104.496 0 25.057 25.057 0 01-4.496 0z" clip-rule="evenodd"/>
+                """);
         }
 
         [Theory]
@@ -221,7 +227,11 @@
             helper.Process(context, output);
 
             // Then
-            output.PreElement.GetContent().ShouldBe("<!-- Heroicon name: outline bell -->");
+            output.PreElement.GetContent().ShouldBe(
+                """
+                <!-- Heroicon name: outline bell -->
+
+                """);
         }
     }
 }


### PR DESCRIPTION
This bumps the heroicons package from 1.0.6 to 2.0.3. Due to a number of missing/incorrectly named icons versions 2.0.0, 2.0.1, and 2.0.2 were skipped. This also adds support for the new mini variant using the tag `heroicon-mini`.