### PR TITLE
Generate documentation file on build and include in nupkg

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,14 @@
         "global.json" : "json5"
     },
     "cSpell.words": [
+        "cref",
         "evenodd",
         "heroicon",
         "heroicons",
+        "inheritdoc",
+        "labeledby",
         "linecap",
-        "linejoin"
+        "linejoin",
+        "viewbox"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - A lot of icons were renamed in this release, see the `Update icon names` section in the [2.0.0 release notes](https://github.com/tailwindlabs/heroicons/releases/tag/v2.0.0) for more details
   - The new mini variant is available using the tag name `heroicon-mini` which supports the same settings as the solid variant
 - Dropped support for .NET 5 which is no longer supported
+- Fixed xml documentation file so it's included in the package
 - Switched from [actions/setup-dotnet](https://github.com/actions/setup-dotnet) to [xt0rted/setup-dotnet](https://github.com/xt0rted/setup-dotnet)
 
 ## [1.0.6](https://github.com/xt0rted/heroicons-tag-helper/compare/v1.0.5...v1.0.6) - 2022-03-15

--- a/generator/IconSourceGenerator.cs
+++ b/generator/IconSourceGenerator.cs
@@ -72,6 +72,9 @@ public class IconSourceGenerator : ISourceGenerator
             """
             namespace Tailwind.Heroicons
             {
+                /// <summary>
+                /// The available icons.
+                /// </summary>
                 public enum IconSymbol
                 {
 
@@ -102,6 +105,9 @@ public class IconSourceGenerator : ISourceGenerator
             {
                 using System;
 
+                /// <summary>
+                /// Helper used to get parsed icon details.
+                /// </summary>
                 public static class IconList
                 {
 
@@ -109,12 +115,14 @@ public class IconSourceGenerator : ISourceGenerator
 
         foreach (var style in icons)
         {
-            source.Append("        public static Icon ");
-            source.Append(style.Key.FirstCharToUpper());
-            source.Append("(IconSymbol symbol");
             source.AppendLine(
-                """
-                )
+                $$"""
+                        /// <summary>
+                        /// Get the details of an icon in the {{style.Key.FirstCharToUpper()}} variation.
+                        /// </summary>
+                        /// <param name="symbol">The <see cref="IconSymbol"/> to get the details of.</param>
+                        /// <returns>The icon details.</returns>
+                        public static Icon {{style.Key.FirstCharToUpper()}}(IconSymbol symbol)
                         {
                             switch (symbol)
                             {
@@ -144,7 +152,7 @@ public class IconSourceGenerator : ISourceGenerator
                 }
 
                 source.AppendLine("                    };");
-                source.AppendLine("");
+                source.AppendLine();
             }
 
             source.AppendLine(
@@ -160,11 +168,29 @@ public class IconSourceGenerator : ISourceGenerator
             """
                 }
 
+                /// <summary>
+                /// A parsed Heroicon.
+                /// </summary>
                 public class Icon
                 {
+                    /// <summary>
+                    /// The filename without extension.
+                    /// </summary>
                     public string Name { get; set; }
+
+                    /// <summary>
+                    /// The svg path element.
+                    /// </summary>
                     public string Path { get; set; }
+
+                    /// <summary>
+                    /// The svg <c>viewbox</c> attribute value.
+                    /// </summary>
                     public string ViewBox { get; set; }
+
+                    /// <summary>
+                    /// The svg <c>stroke-width</c> attribute value.
+                    /// </summary>
                     public string StrokeWidth { get; set; }
                 }
             }

--- a/src/HeroiconOptions.cs
+++ b/src/HeroiconOptions.cs
@@ -1,5 +1,8 @@
 ﻿namespace Tailwind.Heroicons;
 
+/// <summary>
+/// Global settings used when emitting Heroicons.
+/// </summary>
 public class HeroiconOptions
 {
     /// <summary>

--- a/src/HeroiconsExtensions.cs
+++ b/src/HeroiconsExtensions.cs
@@ -1,22 +1,31 @@
 ﻿namespace Microsoft.Extensions.DependencyInjection;
 
+/// <summary>
+/// Contains extension methods to <see cref="IServiceCollection"/> for configuring heroicons.
+/// </summary>
 public static class HeroiconsExtensions
 {
+    /// <summary>
+    /// Adds the default heroicons configuration.
+    /// </summary>
+    /// <param name="services">The services available in the application.</param>
+    /// <param name="configuration">The configuration available in the application.</param>
+    /// <returns>The services.</returns>
     public static IServiceCollection AddHeroicons(this IServiceCollection services, IConfiguration configuration)
     {
-        if (services is null) throw new ArgumentNullException(nameof(services));
-        if (configuration is null) throw new ArgumentNullException(nameof(configuration));
-
         services.Configure<HeroiconOptions>(configuration.GetSection("Heroicons"));
 
         return services;
     }
 
+    /// <summary>
+    /// Adds a custom heroicons configuration.
+    /// </summary>
+    /// <param name="services">The services available in the application.</param>
+    /// <param name="configureOptions">An action to configure the <see cref="HeroiconOptions"/>.</param>
+    /// <returns>The services.</returns>
     public static IServiceCollection AddHeroicons(this IServiceCollection services, Action<HeroiconOptions> configureOptions)
     {
-        if (services is null) throw new ArgumentNullException(nameof(services));
-        if (configureOptions is null) throw new ArgumentNullException(nameof(configureOptions));
-
         services.Configure(configureOptions);
 
         return services;

--- a/src/HeroiconsTagHelper.csproj
+++ b/src/HeroiconsTagHelper.csproj
@@ -8,6 +8,7 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IsPackable>true</IsPackable>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/IconAccessibilityTagHelper.cs
+++ b/src/IconAccessibilityTagHelper.cs
@@ -1,18 +1,28 @@
 ﻿namespace Tailwind.Heroicons;
 
+/// <summary>
+/// Tag helper that sets the <code>aria-hidden</code> or <code>role</code> attribute based on if <code>aria-label</code> or <code>aria-labeledby</code> are set.
+/// </summary>
 [HtmlTargetElement("heroicon-outline")]
 [HtmlTargetElement("heroicon-solid")]
 public class IconAccessibilityTagHelper : TagHelper
 {
     private readonly HeroiconOptions _settings;
 
+    /// <summary>
+    /// Creates a new <see cref="IconAccessibilityTagHelper"/>.
+    /// </summary>
+    /// <param name="settings">The <see cref="HeroiconOptions"/> to use when processing the target element.</param>
+    /// <exception cref="ArgumentNullException"></exception>
     public IconAccessibilityTagHelper(IOptions<HeroiconOptions> settings)
     {
         _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
     }
 
+    /// <inheritdoc/>
     public override int Order => 1000;
 
+    /// <inheritdoc/>
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         if (context is null) throw new ArgumentNullException(nameof(context));

--- a/src/IconFocusableTagHelper.cs
+++ b/src/IconFocusableTagHelper.cs
@@ -1,18 +1,28 @@
 ﻿namespace Tailwind.Heroicons;
 
+/// <summary>
+/// Tag helper that sets <code>focusable="false"</code> on <see cref="IconTagHelper"/> instances.
+/// </summary>
 [HtmlTargetElement("heroicon-outline")]
 [HtmlTargetElement("heroicon-solid")]
 public class IconFocusableTagHelper : TagHelper
 {
     private readonly HeroiconOptions _settings;
 
+    /// <summary>
+    /// Creates a new <see cref="IconFocusableTagHelper"/>.
+    /// </summary>
+    /// <param name="settings">The <see cref="HeroiconOptions"/> to use when processing the target element.</param>
+    /// <exception cref="ArgumentNullException"></exception>
     public IconFocusableTagHelper(IOptions<HeroiconOptions> settings)
     {
         _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
     }
 
+    /// <inheritdoc/>
     public override int Order => 1000;
 
+    /// <inheritdoc/>
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         if (context is null) throw new ArgumentNullException(nameof(context));

--- a/src/IconTagHelper.cs
+++ b/src/IconTagHelper.cs
@@ -1,6 +1,8 @@
 ﻿namespace Tailwind.Heroicons;
 
-
+/// <summary>
+/// Tag helper that emits Heroicon icons as inline svg elements.
+/// </summary>
 [HtmlTargetElement("heroicon-mini", TagStructure = TagStructure.WithoutEndTag)]
 [HtmlTargetElement("heroicon-outline", TagStructure = TagStructure.WithoutEndTag)]
 [HtmlTargetElement("heroicon-solid", TagStructure = TagStructure.WithoutEndTag)]
@@ -8,19 +10,32 @@ public class IconTagHelper : TagHelper
 {
     private readonly HeroiconOptions _settings;
 
+    /// <summary>
+    /// Creates a new <see cref="IconTagHelper"/>.
+    /// </summary>
+    /// <param name="settings">The <see cref="HeroiconOptions"/> to use when processing the target element.</param>
+    /// <exception cref="ArgumentNullException"></exception>
     public IconTagHelper(IOptions<HeroiconOptions> settings)
     {
         _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
     }
 
+    /// <inheritdoc/>
     public override int Order => 0;
 
+    /// <summary>
+    /// The name of the Heroicon to use.
+    /// </summary>
     [HtmlAttributeName("icon")]
     public IconSymbol Icon { get; set; }
 
+    /// <summary>
+    /// Custom stroke width to use for the outline variants.
+    /// </summary>
     [HtmlAttributeName("stroke-width")]
     public string StrokeWidth { get; set; }
 
+    /// <inheritdoc/>
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         if (context is null) throw new ArgumentNullException(nameof(context));


### PR DESCRIPTION
Even though a couple main things like the `IconSymbol` enum had comments, the xml file wasn't being generated or included in the nupkg. This should fix that while also adding comments for everything else.