### PR TITLE
Support mini variant

### DIFF
--- a/src/IconAccessibilityTagHelper.cs
+++ b/src/IconAccessibilityTagHelper.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Tag helper that sets the <code>aria-hidden</code> or <code>role</code> attribute based on if <code>aria-label</code> or <code>aria-labeledby</code> are set.
 /// </summary>
+[HtmlTargetElement("heroicon-mini")]
 [HtmlTargetElement("heroicon-outline")]
 [HtmlTargetElement("heroicon-solid")]
 public class IconAccessibilityTagHelper : TagHelper

--- a/src/IconFocusableTagHelper.cs
+++ b/src/IconFocusableTagHelper.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Tag helper that sets <code>focusable="false"</code> on <see cref="IconTagHelper"/> instances.
 /// </summary>
+[HtmlTargetElement("heroicon-mini")]
 [HtmlTargetElement("heroicon-outline")]
 [HtmlTargetElement("heroicon-solid")]
 public class IconFocusableTagHelper : TagHelper


### PR DESCRIPTION
Support the mini variant on the accessibility and focusable tag helpers. This was missed in #186.