### PR TITLE
Set output element hint to `svg`

### DIFF
--- a/src/IconTagHelper.cs
+++ b/src/IconTagHelper.cs
@@ -6,6 +6,7 @@
 [HtmlTargetElement("heroicon-mini", TagStructure = TagStructure.WithoutEndTag)]
 [HtmlTargetElement("heroicon-outline", TagStructure = TagStructure.WithoutEndTag)]
 [HtmlTargetElement("heroicon-solid", TagStructure = TagStructure.WithoutEndTag)]
+[OutputElementHint("svg")]
 public class IconTagHelper : TagHelper
 {
     private readonly HeroiconOptions _settings;


### PR DESCRIPTION
From what I can tell this should help IDEs identify the `heroicon-*` tags as `svg` elements and give better attribute autocompletion.